### PR TITLE
Avoid copy of vectors for efficiency

### DIFF
--- a/src/forecast_machine.cpp
+++ b/src/forecast_machine.cpp
@@ -499,7 +499,7 @@ void ForecastMachine::simplex_prediction(const size_t start, const size_t end)
             temp_lib = which_lib;
             adjust_lib(curr_pred);
             nearest_neighbors = find_nearest_neighbors(distances[curr_pred]);
-            which_lib = temp_lib;
+            which_lib.swap(temp_lib);
         }
         else
         {
@@ -607,7 +607,7 @@ void ForecastMachine::smap_prediction(const size_t start, const size_t end)
             temp_lib = which_lib;
             adjust_lib(curr_pred);
             nearest_neighbors = find_nearest_neighbors(distances[curr_pred]);
-            which_lib = temp_lib;
+            which_lib.swap(temp_lib);
         }
         else
         {

--- a/src/xmap.cpp
+++ b/src/xmap.cpp
@@ -304,7 +304,7 @@ void Xmap::run()
             }
         }
     }
-    which_lib = full_lib;
+    which_lib.swap(full_lib);
     return;
 }
 


### PR DESCRIPTION
It is better to swap vectors in constant time than copying them in O(n) time.