### PR TITLE
Fix the prefix of column names for the constant predictor in help

### DIFF
--- a/R/block_lnlp_interface.R
+++ b/R/block_lnlp_interface.R
@@ -77,10 +77,10 @@
 #'   \code{perc} \tab percent correct sign\cr
 #'   \code{p_val} \tab p-value that rho is significantly greater than 0 using 
 #'     Fisher's z-transformation\cr
-#'   \code{const_rho} \tab same as \code{rho}, but for the constant predictor\cr
-#'   \code{const_mae} \tab same as \code{mae}, but for the constant predictor\cr
-#'   \code{const_rmse} \tab same as \code{rmse}, but for the constant predictor\cr
-#'   \code{const_perc} \tab same as \code{perc}, but for the constant predictor\cr
+#'   \code{const_pred_rho} \tab same as \code{rho}, but for the constant predictor\cr
+#'   \code{const_pred_mae} \tab same as \code{mae}, but for the constant predictor\cr
+#'   \code{const_pred_rmse} \tab same as \code{rmse}, but for the constant predictor\cr
+#'   \code{const_pred_perc} \tab same as \code{perc}, but for the constant predictor\cr
 #'   \code{const_p_val} \tab same as \code{p_val}, but for the constant predictor\cr
 #'   \code{model_output} \tab data.frame with columns for the time index, 
 #'     observations, predictions, and estimated prediction variance

--- a/R/lnlp_interface.R
+++ b/R/lnlp_interface.R
@@ -59,10 +59,10 @@
 #'   \code{perc} \tab percent correct sign\cr
 #'   \code{p_val} \tab p-value that rho is significantly greater than 0 using 
 #'     Fisher's z-transformation\cr
-#'   \code{const_rho} \tab same as \code{rho}, but for the constant predictor\cr
-#'   \code{const_mae} \tab same as \code{mae}, but for the constant predictor\cr
-#'   \code{const_rmse} \tab same as \code{rmse}, but for the constant predictor\cr
-#'   \code{const_perc} \tab same as \code{perc}, but for the constant predictor\cr
+#'   \code{const_pred_rho} \tab same as \code{rho}, but for the constant predictor\cr
+#'   \code{const_pred_mae} \tab same as \code{mae}, but for the constant predictor\cr
+#'   \code{const_pred_rmse} \tab same as \code{rmse}, but for the constant predictor\cr
+#'   \code{const_pred_perc} \tab same as \code{perc}, but for the constant predictor\cr
 #'   \code{const_p_val} \tab same as \code{p_val}, but for the constant predictor\cr
 #'   \code{model_output} \tab data.frame with columns for the time index, 
 #'     observations, predictions, and estimated prediction variance

--- a/man/block_lnlp.Rd
+++ b/man/block_lnlp.Rd
@@ -75,10 +75,10 @@ A data.frame with components for the parameters and forecast
   \code{perc} \tab percent correct sign\cr
   \code{p_val} \tab p-value that rho is significantly greater than 0 using 
     Fisher's z-transformation\cr
-  \code{const_rho} \tab same as \code{rho}, but for the constant predictor\cr
-  \code{const_mae} \tab same as \code{mae}, but for the constant predictor\cr
-  \code{const_rmse} \tab same as \code{rmse}, but for the constant predictor\cr
-  \code{const_perc} \tab same as \code{perc}, but for the constant predictor\cr
+  \code{const_pred_rho} \tab same as \code{rho}, but for the constant predictor\cr
+  \code{const_pred_mae} \tab same as \code{mae}, but for the constant predictor\cr
+  \code{const_pred_rmse} \tab same as \code{rmse}, but for the constant predictor\cr
+  \code{const_pred_perc} \tab same as \code{perc}, but for the constant predictor\cr
   \code{const_p_val} \tab same as \code{p_val}, but for the constant predictor\cr
   \code{model_output} \tab data.frame with columns for the time index, 
     observations, predictions, and estimated prediction variance

--- a/man/simplex.Rd
+++ b/man/simplex.Rd
@@ -78,10 +78,10 @@ For \code{\link{simplex}}, a data.frame with components for the
   \code{perc} \tab percent correct sign\cr
   \code{p_val} \tab p-value that rho is significantly greater than 0 using 
     Fisher's z-transformation\cr
-  \code{const_rho} \tab same as \code{rho}, but for the constant predictor\cr
-  \code{const_mae} \tab same as \code{mae}, but for the constant predictor\cr
-  \code{const_rmse} \tab same as \code{rmse}, but for the constant predictor\cr
-  \code{const_perc} \tab same as \code{perc}, but for the constant predictor\cr
+  \code{const_pred_rho} \tab same as \code{rho}, but for the constant predictor\cr
+  \code{const_pred_mae} \tab same as \code{mae}, but for the constant predictor\cr
+  \code{const_pred_rmse} \tab same as \code{rmse}, but for the constant predictor\cr
+  \code{const_pred_perc} \tab same as \code{perc}, but for the constant predictor\cr
   \code{const_p_val} \tab same as \code{p_val}, but for the constant predictor\cr
   \code{model_output} \tab data.frame with columns for the time index, 
     observations, predictions, and estimated prediction variance


### PR DESCRIPTION
Help for simplex mentioned column "const_rho", etc., but in reality
the returned data frame has columns "const_pred_rho", etc.
By the way "const_p_val" is an exception.